### PR TITLE
Improve e2e script

### DIFF
--- a/e2e/e2e-script.sh
+++ b/e2e/e2e-script.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euxo pipefail
 source e2e-helper.sh
 echo "Starting e2e tests"
 
@@ -20,8 +21,9 @@ fi
 if [ -z $(az aks list -g $RESOURCE_GROUP_NAME | jq '.[].name') ]; then
     echo "Cluster doesnt exist, creating"
     az aks create -g $RESOURCE_GROUP_NAME -n $CLUSTER_NAME --node-count 1 --generate-ssh-keys
-    az aks get-credentials -g $RESOURCE_GROUP_NAME -n $CLUSTER_NAME
 fi
+
+az aks get-credentials -g $RESOURCE_GROUP_NAME -n $CLUSTER_NAME
 
 # Store the contents of az aks show to a file to reduce API call overhead
 az aks show -n $CLUSTER_NAME -g $RESOURCE_GROUP_NAME > cluster_info.json
@@ -45,18 +47,17 @@ az vmss run-command invoke \
 #       an error saying that extension is still being applied. Need to introduce some delay before this piece of code is
 #       called and the file is ready to be read else the whole flow will break. 
 
-declare -a files=("apiserver.crt" "ca.crt" "client.key" "client.crt")
+declare -a files=("apiserver.crt" "ca.crt" "client.key")
 for file in "${files[@]}"; do
-    sleep 60s
     content=$(az vmss run-command invoke \
                 -n $VMSS_NAME \
                 -g $MC_RESOURCE_GROUP_NAME \
                 --command-id RunShellScript \
                 --instance-id 0 \
-                --scripts "cat /etc/kubernetes/certs/$file" | \
+                --scripts "cat /etc/kubernetes/certs/$file | base64 -w 0" | \
                 jq -r '.value[].message' | \
                 awk '/stdout/{flag=1;next}/stderr/{flag=0}flag' | \
-                awk NF | base64 \
+                awk NF \
             )
     addJsonToFile $file $content
 done
@@ -70,8 +71,9 @@ addJsonToFile "mcRGName" $MC_RESOURCE_GROUP_NAME
 addJsonToFile "clusterID" $CLUSTER_ID
 addJsonToFile "subID" $SUBSCRIPTION_ID
 
+# TODO(ace): generate fresh bootstrap token since one on node will expire.
 # Check if TLS Bootstrapping is enabled(no client.crt in that case, retrieve the tlsbootstrap token)
-sleep 60s
+sleep 30s
 tlsbootstrap=$(az vmss run-command invoke \
                 -n $VMSS_NAME \
                 -g $MC_RESOURCE_GROUP_NAME \
@@ -83,7 +85,7 @@ tlsbootstrap=$(az vmss run-command invoke \
                 cut -f2 -d ":" | tr -d '"'
             )
 
-if [[ -z ${tlsbootstrap} ]]; then
+if [[ -z "${tlsbootstrap}" ]]; then
     echo "TLS Bootstrap disabled"
 else
     addJsonToFile "tlsbootstraptoken" $tlsbootstrap
@@ -97,8 +99,10 @@ go test -run TestE2EBasic
 #       However, how to incorporate chaning quarters?
 
 # TODO 4: Random name for the VMSS for when we have multiple scenarios to run
+RAND_NAME="$(tr -dc '[:lower:]' < /dev/urandom | fold -w 8 | head -n 1)"
+VMSS_NAME="abtest-$RAND_NAME"
 
-az vmss create -n agentbaker-test-vmss \
+az vmss create -n ${VMSS_NAME} \
     -g $MC_RESOURCE_GROUP_NAME \
     --admin-username azureuser \
     --custom-data cloud-init.txt \
@@ -111,19 +115,19 @@ az vmss create -n agentbaker-test-vmss \
 
 # Get the name of the VM instance to later check with kubectl get nodes
 vmInstanceName=$(az vmss list-instances \
-                -n agentbaker-test-vmss \
+                -n ${VMSS_NAME} \
                 -g $MC_RESOURCE_GROUP_NAME | \
                 jq -r '.[].osProfile.computerName'
             )
 export vmInstanceName
 
-# Generate the extension from cseCmd
-jq -Rs '{commandToExecute: . }' cseCmd > settings.json
+# Generate the extension from csecmd
+jq -Rs '{commandToExecute: . }' csecmd > settings.json
 
 # Apply extension to the VM
 az vmss extension set --resource-group $MC_RESOURCE_GROUP_NAME \
     --name CustomScript \
-    --vmss-name agentbaker-test-vmss \
+    --vmss-name ${VMSS_NAME} \
     --publisher Microsoft.Azure.Extensions \
     --protected-settings settings.json \
     --version 2.0
@@ -139,11 +143,7 @@ else
 fi
 
 # Run a nginx pod on the node to check if pod runs
-( echo "cat <<EOF >pod-nginx.yaml";
-  cat pod-nginx-template.yaml;
-) >temp.yaml
-. temp.yaml
-
+envsubst < pod-nginx-template.yaml > pod-nginx.yaml
 kubectl apply -f pod-nginx.yaml
 
 # Sleep to let Pod Status=Running

--- a/e2e/pod-nginx-template.yaml
+++ b/e2e/pod-nginx-template.yaml
@@ -10,4 +10,4 @@ spec:
     image: nginx
     imagePullPolicy: IfNotPresent
   nodeSelector:
-    kubernetes.io/hostname: ${computerName}
+    kubernetes.io/hostname: ${vmInstanceName}


### PR DESCRIPTION
This PR improves the e2e script.

Summary of changes:

- Avoid altering the user's global kubeconfig file.
- Explicitly use JSON output in all `az` commands to mitigate environment variations.
- Allow overriding script params using env vars.
- Wrap fragile API calls in retry logic.
- Fix masked exit codes in calls to the Azure API.
- Misc cleanups.

Note: This PR depends on https://github.com/Azure/AgentBaker/pull/1310. Therefore, I've opened *this* PR against the 1310 branch as I was told GitHub is smart enough to "redirect" this PR to upstream `master` once the dependency PR is merged :crossed_fingers: 